### PR TITLE
Typedef naming pass, early work on #8

### DIFF
--- a/src/_rt_acto.h
+++ b/src/_rt_acto.h
@@ -253,7 +253,7 @@ typedef struct
 	thingtype which;
 	byte tilex, tiley;
 	fixed x, y, z;
-} tpoint;
+} thing_point;
 
 //========================== Function Prototypes ==============================
 

--- a/src/_rt_com.h
+++ b/src/_rt_com.h
@@ -38,13 +38,13 @@ typedef struct
 	int clocktime;
 	int delta;
 	byte data[SYNCPACKETSIZE];
-} syncpackettype;
+} sync_packet_type;
 
 typedef struct
 {
 	int sendtime;
 	int deltatime;
-	syncpackettype pkt;
-} synctype;
+	sync_packet_type pkt;
+} sync_type;
 
 #endif

--- a/src/_rt_net.h
+++ b/src/_rt_net.h
@@ -75,14 +75,14 @@ typedef enum
 	scfp_gameready,
 	scfp_data,
 	scfp_done
-} setupcheckforpacketstate;
+} en_packetstate;
 
 typedef enum
 {
 	cs_ready,
 	cs_notarrived,
 	cs_fixing
-} en_CommandStatus;
+} en_commandstatus;
 
 typedef enum
 {

--- a/src/_rt_soun.h
+++ b/src/_rt_soun.h
@@ -96,7 +96,7 @@ typedef enum
 {
 	loop_yes,
 	loop_no
-} looptypes;
+} en_loop;
 
 typedef struct
 {

--- a/src/_rt_stat.h
+++ b/src/_rt_stat.h
@@ -34,7 +34,7 @@ typedef struct
 {
 	int tictime, numanims;
 	char firstlump[9];
-} awallinfo_t;
+} animwallinfo_t;
 
 typedef struct sas
 {

--- a/src/_rt_ted.h
+++ b/src/_rt_ted.h
@@ -35,7 +35,7 @@ typedef struct
 	int lump;
 	int cachelevel;
 	int type; // To make precaching possible on big endian machines
-} cachetype;
+} cache_type;
 
 //========================================
 
@@ -44,7 +44,7 @@ typedef struct
 	short RLEWtag;
 	int headeroffsets[100];
 	byte tileinfo[1];
-} mapfiletype;
+} map_file_type;
 
 typedef struct
 {
@@ -52,7 +52,7 @@ typedef struct
 	word planelength[3];
 	word width, height;
 	char name[16];
-} maptype;
+} map_type;
 
 #define ActorIsPushWall(xx, yy)                                                \
 	((actorat[xx][yy]) && (((objtype*)actorat[xx][yy])->which == PWALL))

--- a/src/audiolib/_multivc.h
+++ b/src/audiolib/_multivc.h
@@ -83,7 +83,7 @@ typedef enum
 {
 	NoMoreData,
 	KeepPlaying
-} playbackstatus;
+} snd_playstate;
 
 typedef struct VoiceNode
 {
@@ -93,7 +93,7 @@ typedef struct VoiceNode
 	wavedata wavetype;
 	char bits;
 
-	playbackstatus (*GetSound)(struct VoiceNode* voice);
+	snd_playstate (*GetSound)(struct VoiceNode* voice);
 
 	void (*mix)(unsigned long position, unsigned long rate, const char* start,
 				unsigned long length);
@@ -131,13 +131,13 @@ typedef struct
 {
 	VoiceNode* start;
 	VoiceNode* end;
-} VList;
+} VoiceList;
 
 typedef struct
 {
 	unsigned char left;
 	unsigned char right;
-} Pan;
+} AudioPan;
 
 typedef signed short MONO16;
 typedef signed char MONO8;
@@ -199,10 +199,10 @@ static void MV_PlayVoice(VoiceNode* voice);
 static void MV_StopVoice(VoiceNode* voice);
 static void MV_ServiceVoc(void);
 
-static playbackstatus MV_GetNextVOCBlock(VoiceNode* voice);
-static playbackstatus MV_GetNextDemandFeedBlock(VoiceNode* voice);
-static playbackstatus MV_GetNextRawBlock(VoiceNode* voice);
-static playbackstatus MV_GetNextWAVBlock(VoiceNode* voice);
+static snd_playstate MV_GetNextVOCBlock(VoiceNode* voice);
+static snd_playstate MV_GetNextDemandFeedBlock(VoiceNode* voice);
+static snd_playstate MV_GetNextRawBlock(VoiceNode* voice);
+static snd_playstate MV_GetNextWAVBlock(VoiceNode* voice);
 
 static void MV_ServiceRecord(void);
 static VoiceNode* MV_GetVoice(int handle);

--- a/src/audiolib/multivoc.c
+++ b/src/audiolib/multivoc.c
@@ -59,8 +59,8 @@ static VOLUME16* MV_ReverbTable = NULL;
 // static signed short MV_VolumeTable[ MV_MaxVolume + 1 ][ 256 ];
 static signed short MV_VolumeTable[63 + 1][256];
 
-// static Pan MV_PanTable[ MV_NumPanPositions ][ MV_MaxVolume + 1 ];
-static Pan MV_PanTable[MV_NumPanPositions][63 + 1];
+// static AudioPan MV_PanTable[ MV_NumPanPositions ][ MV_MaxVolume + 1 ];
+static AudioPan MV_PanTable[MV_NumPanPositions][63 + 1];
 
 static int MV_Installed = FALSE;
 static int MV_SoundCard = SoundBlaster;
@@ -556,7 +556,7 @@ static __inline unsigned int get_le16(void* p0)
 	return ((unsigned int)(BUILDSWAP_INTEL16(val)));
 }
 
-playbackstatus MV_GetNextVOCBlock(VoiceNode* voice)
+snd_playstate MV_GetNextVOCBlock(VoiceNode* voice)
 
 {
 	unsigned char* ptr;
@@ -831,7 +831,7 @@ playbackstatus MV_GetNextVOCBlock(VoiceNode* voice)
    Controls playback of demand fed data.
 ---------------------------------------------------------------------*/
 
-playbackstatus MV_GetNextDemandFeedBlock(VoiceNode* voice)
+snd_playstate MV_GetNextDemandFeedBlock(VoiceNode* voice)
 
 {
 	if (voice->BlockLength > 0)
@@ -869,7 +869,7 @@ playbackstatus MV_GetNextDemandFeedBlock(VoiceNode* voice)
    Controls playback of demand fed data.
 ---------------------------------------------------------------------*/
 
-playbackstatus MV_GetNextRawBlock(VoiceNode* voice)
+snd_playstate MV_GetNextRawBlock(VoiceNode* voice)
 
 {
 	if (voice->BlockLength <= 0)
@@ -906,7 +906,7 @@ playbackstatus MV_GetNextRawBlock(VoiceNode* voice)
    Controls playback of demand fed data.
 ---------------------------------------------------------------------*/
 
-playbackstatus MV_GetNextWAVBlock(VoiceNode* voice)
+snd_playstate MV_GetNextWAVBlock(VoiceNode* voice)
 
 {
 	if (voice->BlockLength <= 0)

--- a/src/cin_actr.c
+++ b/src/cin_actr.c
@@ -22,8 +22,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "cin_efct.h"
 #include "modexlib.h"
 
-actortype* firstcinematicactor;
-actortype* lastcinematicactor;
+cineactor_type* firstcinematicactor;
+cineactor_type* lastcinematicactor;
 
 // LOCALS
 
@@ -38,7 +38,7 @@ static int numcinematicactors;
 ===============
 */
 
-void AddCinematicActor(actortype* actor)
+void AddCinematicActor(cineactor_type* actor)
 {
 	if (!firstcinematicactor)
 	{
@@ -60,7 +60,7 @@ void AddCinematicActor(actortype* actor)
 ===============
 */
 
-void DeleteCinematicActor(actortype* actor)
+void DeleteCinematicActor(cineactor_type* actor)
 {
 	if (actor == lastcinematicactor)
 	{
@@ -96,16 +96,16 @@ void DeleteCinematicActor(actortype* actor)
 ===============
 */
 
-actortype* GetNewCinematicActor(void)
+cineactor_type* GetNewCinematicActor(void)
 {
-	actortype* actor;
+	cineactor_type* actor;
 
 	numcinematicactors++;
 
 	if (numcinematicactors > MAXCINEMATICACTORS)
 		Error("Too many Cinematic actors\n");
 
-	actor = SafeMalloc(sizeof(actortype));
+	actor = SafeMalloc(sizeof(cineactor_type));
 
 	actor->next = NULL;
 	actor->prev = NULL;
@@ -144,7 +144,7 @@ void StartupCinematicActors(void)
 
 void ShutdownCinematicActors(void)
 {
-	actortype* actor;
+	cineactor_type* actor;
 	if (cinematicactorsystemstarted == false)
 		return;
 	cinematicactorsystemstarted = false;
@@ -152,7 +152,7 @@ void ShutdownCinematicActors(void)
 	actor = firstcinematicactor;
 	while (actor != NULL)
 	{
-		actortype* nextactor;
+		cineactor_type* nextactor;
 
 		nextactor = actor->next;
 		DeleteCinematicActor(actor);
@@ -168,9 +168,9 @@ void ShutdownCinematicActors(void)
 ===============
 */
 
-void SpawnCinematicActor(enum_eventtype type, void* effect)
+void SpawnCinematicActor(en_cinefxevent_t type, void* effect)
 {
-	actortype* actor;
+	cineactor_type* actor;
 
 	actor = GetNewCinematicActor();
 	actor->effecttype = type;
@@ -186,13 +186,13 @@ void SpawnCinematicActor(enum_eventtype type, void* effect)
 */
 void UpdateCinematicActors(void)
 {
-	actortype* actor;
+	cineactor_type* actor;
 
 	for (actor = firstcinematicactor; actor != NULL;)
 	{
 		if (UpdateCinematicEffect(actor->effecttype, actor->effect) == false)
 		{
-			actortype* nextactor;
+			cineactor_type* nextactor;
 
 			nextactor = actor->next;
 			DeleteCinematicActor(actor);
@@ -219,14 +219,14 @@ typedef enum
 	foregroundsprites,
 	palettefunctions,
 	numdrawphases
-} enum_drawphases;
+} en_drawcinephases;
 
 void DrawCinematicActors(void)
 {
-	actortype* actor;
-	actortype* nextactor;
+	cineactor_type* actor;
+	cineactor_type* nextactor;
 	boolean draw;
-	enum_drawphases sequence;
+	en_drawcinephases sequence;
 #if DUMP
 	int numactors = 0;
 #endif

--- a/src/cin_actr.h
+++ b/src/cin_actr.h
@@ -21,16 +21,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "cin_glob.h"
 #include "cin_def.h"
 
-extern actortype* firstcinematicactor;
-extern actortype* lastcinematicactor;
+extern cineactor_type* firstcinematicactor;
+extern cineactor_type* lastcinematicactor;
 
-void AddCinematicActor(actortype* actor);
-void DeleteCinematicActor(actortype* actor);
+void AddCinematicActor(cineactor_type* actor);
+void DeleteCinematicActor(cineactor_type* actor);
 
-actortype* GetNewCinematicActor(void);
+cineactor_type* GetNewCinematicActor(void);
 void StartupCinematicActors(void);
 void ShutdownCinematicActors(void);
-void SpawnCinematicActor(enum_eventtype type, void* effect);
+void SpawnCinematicActor(en_cinefxevent_t type, void* effect);
 void DrawCinematicActors(void);
 void UpdateCinematicActors(void);
 

--- a/src/cin_def.h
+++ b/src/cin_def.h
@@ -39,31 +39,31 @@ typedef enum
 	cinematicend,
 	blankscreen,
 	clearbuffer
-} enum_eventtype;
+} en_cinefxevent_t;
 
-typedef struct eventtype
+typedef struct en_cinefxevent_node_t
 {
 	int time;
-	enum_eventtype effecttype;
+	en_cinefxevent_t effecttype;
 	void* effect;
-	struct eventtype* next;
-	struct eventtype* prev;
-} eventtype;
+	struct en_cinefxevent_node_t* next;
+	struct en_cinefxevent_node_t* prev;
+} en_cinefxevent_node_t;
 
-typedef struct actortype
+typedef struct cineactor_type
 {
-	enum_eventtype effecttype;
+	en_cinefxevent_t effecttype;
 	void* effect;
-	struct actortype* next;
-	struct actortype* prev;
-} actortype;
+	struct cineactor_type* next;
+	struct cineactor_type* prev;
+} cineactor_type;
 
 typedef struct
 {
 	char name[10];
 	boolean loop;
 	boolean usefile;
-} flicevent;
+} cine_event;
 
 typedef struct
 {
@@ -79,7 +79,7 @@ typedef struct
 	int dx;
 	int dy;
 	int dscale;
-} spriteevent;
+} cinespr_event;
 
 typedef struct
 {
@@ -91,11 +91,11 @@ typedef struct
 	int yoffset;
 	int height;
 	byte* data;
-} backevent;
+} cine_bgevent;
 
 typedef struct
 {
 	char name[10];
-} paletteevent;
+} cine_palevent;
 
 #endif

--- a/src/cin_efct.c
+++ b/src/cin_efct.c
@@ -44,11 +44,11 @@ void DrawClearBuffer(void);
 ===============
 */
 
-flicevent* SpawnCinematicFlic(char* name, boolean loop, boolean usefile)
+cine_event* SpawnCinematicFlic(char* name, boolean loop, boolean usefile)
 {
-	flicevent* f;
+	cine_event* f;
 
-	f = SafeMalloc(sizeof(flicevent));
+	f = SafeMalloc(sizeof(cine_event));
 
 	// copy name of flic
 
@@ -69,13 +69,13 @@ flicevent* SpawnCinematicFlic(char* name, boolean loop, boolean usefile)
 ===============
 */
 
-spriteevent* SpawnCinematicSprite(char* name, int duration, int numframes,
+cinespr_event* SpawnCinematicSprite(char* name, int duration, int numframes,
 								  int framedelay, int x, int y, int scale,
 								  int endx, int endy, int endscale)
 {
-	spriteevent* sprite;
+	cinespr_event* sprite;
 
-	sprite = SafeMalloc(sizeof(spriteevent));
+	sprite = SafeMalloc(sizeof(cinespr_event));
 
 	// copy name of sprite
 
@@ -110,12 +110,12 @@ spriteevent* SpawnCinematicSprite(char* name, int duration, int numframes,
 ===============
 */
 
-backevent* SpawnCinematicBack(char* name, int duration, int width, int startx,
+cine_bgevent* SpawnCinematicBack(char* name, int duration, int width, int startx,
 							  int endx, int yoffset)
 {
-	backevent* back;
+	cine_bgevent* back;
 
-	back = SafeMalloc(sizeof(backevent));
+	back = SafeMalloc(sizeof(cine_bgevent));
 
 	// copy name of back
 
@@ -140,17 +140,17 @@ backevent* SpawnCinematicBack(char* name, int duration, int width, int startx,
 ===============
 */
 
-backevent* SpawnCinematicMultiBack(char* name, char* name2, int duration,
+cine_bgevent* SpawnCinematicMultiBack(char* name, char* name2, int duration,
 								   int startx, int endx, int yoffset)
 {
-	backevent* back;
+	cine_bgevent* back;
 	lpic_t* pic1;
 	lpic_t* pic2;
 
 	pic1 = (lpic_t*)W_CacheLumpName(name, PU_CACHE, Cvt_lpic_t, 1);
 	pic2 = (lpic_t*)W_CacheLumpName(name2, PU_CACHE, Cvt_lpic_t, 1);
 
-	back = SafeMalloc(sizeof(backevent));
+	back = SafeMalloc(sizeof(cine_bgevent));
 
 	// copy name of back
 
@@ -185,11 +185,11 @@ backevent* SpawnCinematicMultiBack(char* name, char* name2, int duration,
 ===============
 */
 
-paletteevent* SpawnCinematicPalette(char* name)
+cine_palevent* SpawnCinematicPalette(char* name)
 {
-	paletteevent* p;
+	cine_palevent* p;
 
-	p = SafeMalloc(sizeof(paletteevent));
+	p = SafeMalloc(sizeof(cine_palevent));
 
 	// copy name of palette
 
@@ -241,7 +241,7 @@ void ScaleFilmPost(byte* src, byte* buf)
 =
 =================
 */
-void DrawFlic(flicevent* f)
+void DrawFlic(cine_event* f)
 {
 	byte* curpal;
 	char flicname[40];
@@ -287,7 +287,7 @@ void DrawFlic(flicevent* f)
 =================
 */
 
-void PrecacheFlic(flicevent* f)
+void PrecacheFlic(cine_event* f)
 {
 	if (f->usefile == false)
 	{
@@ -303,7 +303,7 @@ void PrecacheFlic(flicevent* f)
 ===============
 */
 
-void DrawCinematicBackground(backevent* back)
+void DrawCinematicBackground(cine_bgevent* back)
 {
 	byte* src;
 	byte* buf;
@@ -351,7 +351,7 @@ void DrawCinematicBackground(backevent* back)
 ===============
 */
 
-void DrawCinematicMultiBackground(backevent* back)
+void DrawCinematicMultiBackground(cine_bgevent* back)
 {
 	byte* src;
 	byte* buf;
@@ -396,7 +396,7 @@ void DrawCinematicMultiBackground(backevent* back)
 ===============
 */
 
-void DrawCinematicBackdrop(backevent* back)
+void DrawCinematicBackdrop(cine_bgevent* back)
 {
 	byte* src;
 	byte* shape;
@@ -449,7 +449,7 @@ void DrawCinematicBackdrop(backevent* back)
 =
 =================
 */
-void PrecacheBack(backevent* back)
+void PrecacheBack(cine_bgevent* back)
 {
 	W_CacheLumpName(back->name, PU_CACHE, CvtNull, 1);
 }
@@ -461,7 +461,7 @@ void PrecacheBack(backevent* back)
 =
 =================
 */
-void DrawCinematicSprite(spriteevent* sprite)
+void DrawCinematicSprite(cinespr_event* sprite)
 {
 	byte* shape;
 	int frac;
@@ -529,7 +529,7 @@ void DrawCinematicSprite(spriteevent* sprite)
 =
 =================
 */
-void PrecacheCinematicSprite(spriteevent* sprite)
+void PrecacheCinematicSprite(cinespr_event* sprite)
 {
 	int i;
 
@@ -548,7 +548,7 @@ void PrecacheCinematicSprite(spriteevent* sprite)
 =================
 */
 
-void DrawPalette(paletteevent* event)
+void DrawPalette(cine_palevent* event)
 {
 	byte* pal;
 
@@ -565,7 +565,7 @@ void DrawPalette(paletteevent* event)
 =================
 */
 
-void PrecachePalette(paletteevent* event)
+void PrecachePalette(cine_palevent* event)
 {
 	W_CacheLumpName(event->name, PU_CACHE, CvtNull, 1);
 }
@@ -633,7 +633,7 @@ void DrawClearBuffer(void)
 ===============
 */
 
-boolean UpdateCinematicBack(backevent* back)
+boolean UpdateCinematicBack(cine_bgevent* back)
 {
 	back->duration--;
 
@@ -652,7 +652,7 @@ boolean UpdateCinematicBack(backevent* back)
 =
 =================
 */
-boolean UpdateCinematicSprite(spriteevent* sprite)
+boolean UpdateCinematicSprite(cinespr_event* sprite)
 {
 	sprite->duration--;
 
@@ -683,7 +683,7 @@ boolean UpdateCinematicSprite(spriteevent* sprite)
 =
 =================
 */
-boolean UpdateCinematicEffect(enum_eventtype type, void* effect)
+boolean UpdateCinematicEffect(en_cinefxevent_t type, void* effect)
 {
 	switch (type)
 	{
@@ -692,11 +692,11 @@ boolean UpdateCinematicEffect(enum_eventtype type, void* effect)
 	case backdrop_scrolling:
 	case backdrop_noscrolling:
 	case background_multi:
-		return UpdateCinematicBack((backevent*)effect);
+		return UpdateCinematicBack((cine_bgevent*)effect);
 		break;
 	case sprite_background:
 	case sprite_foreground:
-		return UpdateCinematicSprite((spriteevent*)effect);
+		return UpdateCinematicSprite((cinespr_event*)effect);
 		break;
 	case flic:
 		return true;
@@ -721,35 +721,35 @@ boolean UpdateCinematicEffect(enum_eventtype type, void* effect)
 =
 =================
 */
-boolean DrawCinematicEffect(enum_eventtype type, void* effect)
+boolean DrawCinematicEffect(en_cinefxevent_t type, void* effect)
 {
 	switch (type)
 	{
 	case background_noscrolling:
 	case background_scrolling:
-		DrawCinematicBackground((backevent*)effect);
+		DrawCinematicBackground((cine_bgevent*)effect);
 		return true;
 		break;
 	case background_multi:
-		DrawCinematicMultiBackground((backevent*)effect);
+		DrawCinematicMultiBackground((cine_bgevent*)effect);
 		return true;
 		break;
 	case backdrop_scrolling:
 	case backdrop_noscrolling:
-		DrawCinematicBackdrop((backevent*)effect);
+		DrawCinematicBackdrop((cine_bgevent*)effect);
 		return true;
 		break;
 	case sprite_background:
 	case sprite_foreground:
-		DrawCinematicSprite((spriteevent*)effect);
+		DrawCinematicSprite((cinespr_event*)effect);
 		return true;
 		break;
 	case flic:
-		DrawFlic((flicevent*)effect);
+		DrawFlic((cine_event*)effect);
 		return false;
 		break;
 	case palette:
-		DrawPalette((paletteevent*)effect);
+		DrawPalette((cine_palevent*)effect);
 		return false;
 		break;
 	case fadeout:
@@ -778,7 +778,7 @@ boolean DrawCinematicEffect(enum_eventtype type, void* effect)
 =
 =================
 */
-void PrecacheCinematicEffect(enum_eventtype type, void* effect)
+void PrecacheCinematicEffect(en_cinefxevent_t type, void* effect)
 {
 	switch (type)
 	{
@@ -786,17 +786,17 @@ void PrecacheCinematicEffect(enum_eventtype type, void* effect)
 	case background_scrolling:
 	case backdrop_scrolling:
 	case backdrop_noscrolling:
-		PrecacheBack((backevent*)effect);
+		PrecacheBack((cine_bgevent*)effect);
 		break;
 	case sprite_background:
 	case sprite_foreground:
-		PrecacheCinematicSprite((spriteevent*)effect);
+		PrecacheCinematicSprite((cinespr_event*)effect);
 		break;
 	case palette:
-		PrecachePalette((paletteevent*)effect);
+		PrecachePalette((cine_palevent*)effect);
 		break;
 	case flic:
-		PrecacheFlic((flicevent*)effect);
+		PrecacheFlic((cine_event*)effect);
 		break;
 	default:;
 	}

--- a/src/cin_efct.h
+++ b/src/cin_efct.h
@@ -21,28 +21,28 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "cin_glob.h"
 #include "cin_def.h"
 
-flicevent* SpawnCinematicFlic(char* name, boolean loop, boolean usefile);
-spriteevent* SpawnCinematicSprite(char* name, int duration, int numframes,
+cine_event* SpawnCinematicFlic(char* name, boolean loop, boolean usefile);
+cinespr_event* SpawnCinematicSprite(char* name, int duration, int numframes,
 								  int framedelay, int x, int y, int scale,
 								  int endx, int endy, int endscale);
-backevent* SpawnCinematicBack(char* name, int duration, int width, int startx,
+cine_bgevent* SpawnCinematicBack(char* name, int duration, int width, int startx,
 							  int endx, int yoffset);
 
-backevent* SpawnCinematicMultiBack(char* name, char* name2, int duration,
+cine_bgevent* SpawnCinematicMultiBack(char* name, char* name2, int duration,
 								   int startx, int endx, int yoffset);
-paletteevent* SpawnCinematicPalette(char* name);
-void DrawFlic(flicevent* flic);
-void DrawCinematicBackdrop(backevent* back);
-void DrawCinematicBackground(backevent* back);
-void DrawPalette(paletteevent* event);
-void DrawCinematicSprite(spriteevent* sprite);
+cine_palevent* SpawnCinematicPalette(char* name);
+void DrawFlic(cine_event* flic);
+void DrawCinematicBackdrop(cine_bgevent* back);
+void DrawCinematicBackground(cine_bgevent* back);
+void DrawPalette(cine_palevent* event);
+void DrawCinematicSprite(cinespr_event* sprite);
 void DrawClearBuffer(void);
 void DrawBlankScreen(void);
-boolean DrawCinematicEffect(enum_eventtype type, void* effect);
-boolean UpdateCinematicBack(backevent* back);
-boolean UpdateCinematicSprite(spriteevent* sprite);
-boolean UpdateCinematicEffect(enum_eventtype type, void* effect);
-void PrecacheCinematicEffect(enum_eventtype type, void* effect);
+boolean DrawCinematicEffect(en_cinefxevent_t type, void* effect);
+boolean UpdateCinematicBack(cine_bgevent* back);
+boolean UpdateCinematicSprite(cinespr_event* sprite);
+boolean UpdateCinematicEffect(en_cinefxevent_t type, void* effect);
+void PrecacheCinematicEffect(en_cinefxevent_t type, void* effect);
 void ProfileDisplay(void);
 void DrawPostPic(int lumpnum);
 

--- a/src/cin_evnt.c
+++ b/src/cin_evnt.c
@@ -27,8 +27,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "z_zone.h"
 #include <string.h>
 
-eventtype* firstevent;
-eventtype* lastevent;
+en_cinefxevent_node_t* firstevent;
+en_cinefxevent_node_t* lastevent;
 
 // LOCALS
 
@@ -43,7 +43,7 @@ static boolean eventsystemstarted = false;
 ===============
 */
 
-void AddEvent(eventtype* event)
+void AddEvent(en_cinefxevent_node_t* event)
 {
 	if (!firstevent)
 		firstevent = event;
@@ -63,7 +63,7 @@ void AddEvent(eventtype* event)
 ===============
 */
 
-void DeleteEvent(eventtype* event)
+void DeleteEvent(en_cinefxevent_node_t* event)
 {
 	if (event == lastevent)
 		lastevent = event->prev;
@@ -89,16 +89,16 @@ void DeleteEvent(eventtype* event)
 ===============
 */
 
-eventtype* GetNewEvent(void)
+en_cinefxevent_node_t* GetNewEvent(void)
 {
-	eventtype* event;
+	en_cinefxevent_node_t* event;
 
 	numevents++;
 
 	if (numevents > MAXCINEMATICEVENTS)
 		Error("Too many Cinematic events\n");
 
-	event = SafeMalloc(sizeof(eventtype));
+	event = SafeMalloc(sizeof(en_cinefxevent_node_t));
 
 	event->next = NULL;
 	event->prev = NULL;
@@ -135,7 +135,7 @@ void StartupEvents(void)
 
 void ShutdownEvents(void)
 {
-	eventtype* event;
+	en_cinefxevent_node_t* event;
 
 	if (eventsystemstarted == false)
 		return;
@@ -144,7 +144,7 @@ void ShutdownEvents(void)
 	event = firstevent;
 	while (event != NULL)
 	{
-		eventtype* nextevent;
+		en_cinefxevent_node_t* nextevent;
 
 		nextevent = event->next;
 		DeleteEvent(event);
@@ -159,9 +159,9 @@ void ShutdownEvents(void)
 =
 ===============
 */
-eventtype* CreateEvent(int time, int type)
+en_cinefxevent_node_t* CreateEvent(int time, int type)
 {
-	eventtype* event;
+	en_cinefxevent_node_t* event;
 
 	event = GetNewEvent();
 
@@ -183,7 +183,7 @@ eventtype* CreateEvent(int time, int type)
 =
 ===============
 */
-enum_eventtype GetEventType(void)
+en_cinefxevent_t GetEventType(void)
 {
 	// Get Event Token
 
@@ -271,7 +271,7 @@ enum_eventtype GetEventType(void)
 =
 ===============
 */
-void ParseBack(eventtype* event)
+void ParseBack(en_cinefxevent_node_t* event)
 {
 	char name1[10];
 	char name2[10];
@@ -337,7 +337,7 @@ void ParseBack(eventtype* event)
 =
 ===============
 */
-void ParseSprite(eventtype* event)
+void ParseSprite(en_cinefxevent_node_t* event)
 {
 	char name1[10];
 	int duration;
@@ -378,7 +378,7 @@ void ParseSprite(eventtype* event)
 =
 ===============
 */
-void ParseFlic(eventtype* event)
+void ParseFlic(en_cinefxevent_node_t* event)
 {
 	char name1[10];
 	boolean loop;
@@ -421,7 +421,7 @@ void ParseFlic(eventtype* event)
 =
 ===============
 */
-void ParsePalette(eventtype* event)
+void ParsePalette(en_cinefxevent_node_t* event)
 {
 	char name1[10];
 
@@ -440,7 +440,7 @@ void ParsePalette(eventtype* event)
 */
 void ParseEvent(int time)
 {
-	eventtype* event;
+	en_cinefxevent_node_t* event;
 
 	event = CreateEvent(time, GetEventType());
 
@@ -480,13 +480,13 @@ void ParseEvent(int time)
 */
 void UpdateCinematicEvents(int time)
 {
-	eventtype* event;
+	en_cinefxevent_node_t* event;
 
 	for (event = firstevent; event != NULL;)
 	{
 		if (event->time == time)
 		{
-			eventtype* nextevent;
+			en_cinefxevent_node_t* nextevent;
 
 			nextevent = event->next;
 			SpawnCinematicActor(event->effecttype, event->effect);
@@ -509,7 +509,7 @@ void UpdateCinematicEvents(int time)
 */
 void PrecacheCinematic(void)
 {
-	eventtype* event;
+	en_cinefxevent_node_t* event;
 
 	for (event = firstevent; event != NULL;)
 	{

--- a/src/cin_evnt.h
+++ b/src/cin_evnt.h
@@ -21,16 +21,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include "cin_glob.h"
 #include "cin_def.h"
 
-extern eventtype* firstevent;
-extern eventtype* lastevent;
+extern en_cinefxevent_node_t* firstevent;
+extern en_cinefxevent_node_t* lastevent;
 
-void AddEvent(eventtype* event);
-void DeleteEvent(eventtype* event);
+void AddEvent(en_cinefxevent_node_t* event);
+void DeleteEvent(en_cinefxevent_node_t* event);
 
-eventtype* GetNewEvent(void);
+en_cinefxevent_node_t* GetNewEvent(void);
 void StartupEvents(void);
 void ShutdownEvents(void);
-eventtype* CreateEvent(int time, int type);
+en_cinefxevent_node_t* CreateEvent(int time, int type);
 void ParseEvent(int time);
 void UpdateCinematicEvents(int time);
 void PrecacheCinematic(void);

--- a/src/dukemusc.c
+++ b/src/dukemusc.c
@@ -421,12 +421,12 @@ void MUSIC_SetSongPosition(int measure, int beat, int tick)
 	musdebug("STUB ... MUSIC_SetSongPosition().\n");
 } // MUSIC_SetSongPosition
 
-void MUSIC_GetSongPosition(songposition* pos)
+void MUSIC_GetSongPosition(songtic* pos)
 {
 	musdebug("STUB ... MUSIC_GetSongPosition().\n");
 } // MUSIC_GetSongPosition
 
-void MUSIC_GetSongLength(songposition* pos)
+void MUSIC_GetSongLength(songtic* pos)
 {
 	musdebug("STUB ... MUSIC_GetSongLength().\n");
 } // MUSIC_GetSongLength

--- a/src/music.h
+++ b/src/music.h
@@ -55,7 +55,7 @@ typedef struct
 	unsigned int measure;
 	unsigned int beat;
 	unsigned int tick;
-} songposition;
+} songtic;
 
 #define MUSIC_LoopSong (1 == 1)
 #define MUSIC_PlayOnce (!MUSIC_LoopSong)
@@ -83,8 +83,8 @@ int MUSIC_GetContext(void);
 void MUSIC_SetSongTick(unsigned long PositionInTicks);
 void MUSIC_SetSongTime(unsigned long milliseconds);
 void MUSIC_SetSongPosition(int measure, int beat, int tick);
-void MUSIC_GetSongPosition(songposition* pos);
-void MUSIC_GetSongLength(songposition* pos);
+void MUSIC_GetSongPosition(songtic* pos);
+void MUSIC_GetSongLength(songtic* pos);
 int MUSIC_FadeVolume(int tovolume, int milliseconds);
 int MUSIC_FadeActive(void);
 void MUSIC_StopFade(void);

--- a/src/rottnet.h
+++ b/src/rottnet.h
@@ -58,13 +58,13 @@ typedef struct
 
 	// packet data to be sent
 	char data[MAXPACKETSIZE];
-} rottcom_t;
+} rottcom_info_t;
 
 #define MODEM_GAME	 0
 #define NETWORK_GAME 1
 
 #define ROTTLAUNCHER ("ROTT.EXE")
 
-extern rottcom_t* rottcom;
+extern rottcom_info_t* rottcom;
 
 #endif

--- a/src/rt_actor.c
+++ b/src/rt_actor.c
@@ -94,7 +94,7 @@ byte RANDOMACTORTYPE[10];
 #if (SHAREWARE == 0)
 _2Dpoint SNAKEPATH[512];
 #endif
-misc_stuff mstruct, *MISCVARS = &mstruct;
+actor_misc_flags mstruct, *MISCVARS = &mstruct;
 int angletodir[ANGLES];
 objtype* new;
 
@@ -458,13 +458,13 @@ void SaveActors(byte** buffer, int* size)
 	for (actorcount = 0, temp = FIRSTACTOR; temp; temp = temp->next)
 		temp->whichactor = actorcount++;
 
-	*size = sizeof(int) + sizeof(numplayers) + sizeof(misc_stuff) +
+	*size = sizeof(int) + sizeof(numplayers) + sizeof(actor_misc_flags) +
 			objcount * sizeof(saved_actor_type);
 	*buffer = (byte*)SafeMalloc(*size);
 	tptr = *buffer;
 
-	memcpy(tptr, MISCVARS, sizeof(misc_stuff));
-	tptr += sizeof(misc_stuff);
+	memcpy(tptr, MISCVARS, sizeof(actor_misc_flags));
+	tptr += sizeof(actor_misc_flags);
 
 	memcpy(tptr, &numplayers, sizeof(numplayers));
 	tptr += sizeof(numplayers);
@@ -560,8 +560,8 @@ void LoadActors(byte* buffer, int size)
 
 	InitActorList();
 
-	memcpy(MISCVARS, buffer, sizeof(misc_stuff));
-	buffer += sizeof(misc_stuff);
+	memcpy(MISCVARS, buffer, sizeof(actor_misc_flags));
+	buffer += sizeof(actor_misc_flags);
 
 	memcpy(&numplayers, buffer, sizeof(numplayers));
 	buffer += sizeof(numplayers);
@@ -569,7 +569,7 @@ void LoadActors(byte* buffer, int size)
 	memcpy(&playerindex, buffer, sizeof(playerindex));
 	buffer += sizeof(playerindex);
 
-	size -= (sizeof(misc_stuff) + sizeof(numplayers) + sizeof(playerindex));
+	size -= (sizeof(actor_misc_flags) + sizeof(numplayers) + sizeof(playerindex));
 	numactors = size / sizeof(saved_actor_type);
 
 	objlist = (objtype**)SafeMalloc(numactors * sizeof(objtype*));
@@ -1128,7 +1128,7 @@ void InitActorList(void)
 	//============================================================
 
 	objcount = 0;
-	memset(MISCVARS, 0, sizeof(misc_stuff));
+	memset(MISCVARS, 0, sizeof(actor_misc_flags));
 	MISCVARS->gibgravity = -1;
 	MISCVARS->gibspeed = NORMALGIBSPEED;
 
@@ -7975,7 +7975,7 @@ typedef enum
 hiding_status HoleStatus(objtype* ob)
 {
 	int i, tx, ty, dist, noneleft, invisible, curr, min;
-	tpoint dummy, *dptr = &dummy;
+	thing_point dummy, *dptr = &dummy;
 	objtype* tactor;
 	_2Dpoint* tdptr;
 
@@ -8254,7 +8254,7 @@ void T_HeinrichChase(objtype* ob)
 
 			if (GameRandomNumber("T_HeinrichChase", 0) < chance)
 			{
-				tpoint dummy, *dptr = &dummy;
+				thing_point dummy, *dptr = &dummy;
 
 				if (Near(ob, PLAYER[0], 2))
 					goto cdoor;
@@ -8408,7 +8408,7 @@ void SelectKristChaseDir(objtype* ob)
 {
 	int dx, dy, tx, ty, angle;
 	dirtype dtry1, dtry2, tdir, olddir, next, prev, straight;
-	// tpoint dummy,*dptr=&dummy;
+	// thing_point dummy,*dptr=&dummy;
 
 	olddir = ob->dir;
 
@@ -8440,7 +8440,7 @@ void SelectKristChaseDir(objtype* ob)
 	straight = angletodir[angle];
 	/*
 	if (ob->areanumber == PLAYER[0]->areanumber)
-	  {//tpoint newpos1,newpos2;
+	  {//thing_point newpos1,newpos2;
 		//dirtype leftdir;
 		//int leftangle1,leftangle2;
 
@@ -8565,7 +8565,7 @@ void T_KristRight(objtype* ob)
 void T_KristCheckFire(objtype* ob)
 {
 	int perpangle, angle;
-	tpoint dummy;
+	thing_point dummy;
 
 	if (!ob->ticcount)
 	{
@@ -9552,7 +9552,7 @@ void FindClosestPath(objtype* ob)
 void T_SnakeFindPath(objtype* ob)
 {
 	int i, dx, dy, currdist, mindist, map;
-	tpoint dstruct, *dummy = &dstruct;
+	thing_point dstruct, *dummy = &dstruct;
 	objtype *temp, *follower;
 
 	if (ob->targettilex || ob->targettiley)
@@ -12024,7 +12024,7 @@ void SelectChaseDir(objtype* ob)
 {
 	int dx, dy, whichway, tx, ty, actrad, visible, realdiff;
 	dirtype dtry1, dtry2, tdir, olddir, next, prev, start, straight;
-	tpoint dummy;
+	thing_point dummy;
 	byte dirtried[9] = {0};
 
 	olddir = ob->dir;

--- a/src/rt_actor.h
+++ b/src/rt_actor.h
@@ -270,7 +270,7 @@ typedef struct b_struct
 	boolean randgibspeed;
 	int numgibs;
 	boolean elevatormusicon;
-} misc_stuff;
+} actor_misc_flags;
 
 extern boolean ludicrousgibs;
 extern objtype* PLAYER0MISSILE;
@@ -280,7 +280,7 @@ extern objtype *FIRSTACTOR, *LASTACTOR;
 extern objtype *FIRSTRAIN, *LASTRAIN;
 extern objtype* SCREENEYE;
 extern objtype *firstareaactor[NUMAREAS + 1], *lastareaactor[NUMAREAS + 1];
-extern misc_stuff mstruct, *MISCVARS;
+extern actor_misc_flags mstruct, *MISCVARS;
 extern int actorstart, actorstop;
 extern exit_t playstate;
 extern objtype *lastactive, *firstactive;

--- a/src/rt_battl.c
+++ b/src/rt_battl.c
@@ -46,7 +46,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #define INFINITE -1
 
-static battle_status BATTLE_StartRound(void);
+static battle_state BATTLE_StartRound(void);
 
 static int Timer;
 static int TimeLimit;
@@ -61,7 +61,7 @@ boolean UpdateKills;
 
 static boolean SwapFlag;
 
-static battle_type BattleOptions;
+static battle_cfg_type BattleOptions;
 
 specials BattleSpecialsTimes = {
 	60,					  // god
@@ -396,10 +396,10 @@ void BATTLE_GetSpecials(void)
 	Set the battle options.
 ---------------------------------------------------------------------*/
 
-void BATTLE_SetOptions(battle_type* options)
+void BATTLE_SetOptions(battle_cfg_type* options)
 
 {
-	memcpy(&BattleOptions, options, sizeof(battle_type));
+	memcpy(&BattleOptions, options, sizeof(battle_cfg_type));
 }
 
 /*---------------------------------------------------------------------
@@ -408,10 +408,10 @@ void BATTLE_SetOptions(battle_type* options)
    Returns the battle options.
 ---------------------------------------------------------------------*/
 
-void BATTLE_GetOptions(battle_type* options)
+void BATTLE_GetOptions(battle_cfg_type* options)
 
 {
-	memcpy(options, &BattleOptions, sizeof(battle_type));
+	memcpy(options, &BattleOptions, sizeof(battle_cfg_type));
 }
 
 /*---------------------------------------------------------------------
@@ -466,7 +466,7 @@ void BATTLE_Shutdown(void)
 	Begins a round of battle.
 ---------------------------------------------------------------------*/
 
-static battle_status BATTLE_StartRound(void)
+static battle_state BATTLE_StartRound(void)
 
 {
 	int index;
@@ -531,10 +531,10 @@ static battle_status BATTLE_StartRound(void)
 	determines the appropriate response.
 ---------------------------------------------------------------------*/
 
-battle_status BATTLE_CheckGameStatus(battle_event reason, int player)
+battle_state BATTLE_CheckGameStatus(battle_event reason, int player)
 
 {
-	battle_status status;
+	battle_state status;
 	int team;
 
 	if ((player < 0) || (player >= MAXPLAYERS))
@@ -780,7 +780,7 @@ void BATTLE_SortPlayerRanks(void)
    Increases the number of kills a player has.
 ---------------------------------------------------------------------*/
 
-battle_status BATTLE_PlayerKilledPlayer(battle_event reason, int killer,
+battle_state BATTLE_PlayerKilledPlayer(battle_event reason, int killer,
 										int victim)
 
 {

--- a/src/rt_battl.h
+++ b/src/rt_battl.h
@@ -43,7 +43,7 @@ typedef enum
 	battle_end_game,
 	battle_end_round,
 	battle_out_of_time
-} battle_status;
+} battle_state;
 
 //
 // Types of battle events
@@ -187,7 +187,7 @@ typedef struct
 	int DangerDamage;
 	unsigned TimeLimit;
 	unsigned RespawnTime;
-} battle_type;
+} battle_cfg_type;
 
 #define bo_normal_respawn_time 30
 
@@ -206,15 +206,15 @@ extern int BATTLE_NumberOfTeams;
 extern boolean UpdateKills;
 
 // Located in RT_MENU.C
-extern battle_type BATTLE_Options[battle_NumBattleModes];
+extern battle_cfg_type BATTLE_Options[battle_NumBattleModes];
 
 void BATTLE_Init(int battlemode, int numplayers);
 void BATTLE_GetSpecials(void);
-void BATTLE_SetOptions(battle_type* options);
-void BATTLE_GetOptions(battle_type* options);
-battle_status BATTLE_CheckGameStatus(battle_event reason, int player);
+void BATTLE_SetOptions(battle_cfg_type* options);
+void BATTLE_GetOptions(battle_cfg_type* options);
+battle_state BATTLE_CheckGameStatus(battle_event reason, int player);
 void BATTLE_SortPlayerRanks(void);
-battle_status BATTLE_PlayerKilledPlayer(battle_event reason, int killer,
+battle_state BATTLE_PlayerKilledPlayer(battle_event reason, int killer,
 										int victim);
 void BATTLE_Shutdown(void);
 

--- a/src/rt_com.c
+++ b/src/rt_com.c
@@ -39,7 +39,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // GLOBAL VARIABLES
 
 // Same as in real mode
-rottcom_t* rottcom;
+rottcom_info_t* rottcom;
 int badpacket;
 int consoleplayer;
 byte ROTTpacket[MAXCOMBUFFERSIZE];
@@ -99,8 +99,8 @@ void InitROTTNET(void)
 	-port: select a non-default port to connect to
 	*/
 
-	rottcom = (rottcom_t*)malloc(sizeof(rottcom_t));
-	memset(rottcom, 0, sizeof(rottcom_t));
+	rottcom = (rottcom_info_t*)malloc(sizeof(rottcom_info_t));
+	memset(rottcom, 0, sizeof(rottcom_info_t));
 
 	rottcom->ticstep = 1;
 	rottcom->gametype = 1;
@@ -315,11 +315,11 @@ void WritePacket(void* buffer, int len, int destination)
 =
 =============
 */
-boolean ValidSyncPacket(synctype* sync)
+boolean ValidSyncPacket(sync_type* sync)
 {
 	if (ReadPacket() && (badpacket == 0))
 	{
-		if (((syncpackettype*)&(ROTTpacket[0]))->type == COM_SYNC)
+		if (((sync_packet_type*)&(ROTTpacket[0]))->type == COM_SYNC)
 		{
 			memcpy(&(sync->pkt), &(ROTTpacket[0]), sizeof(sync->pkt));
 			return true;
@@ -335,11 +335,11 @@ boolean ValidSyncPacket(synctype* sync)
 =
 =============
 */
-void SendSyncPacket(synctype* sync, int dest)
+void SendSyncPacket(sync_type* sync, int dest)
 {
 	sync->pkt.type = COM_SYNC;
 	sync->sendtime = GetTicCount();
-	WritePacket(&(sync->pkt.type), sizeof(syncpackettype), dest);
+	WritePacket(&(sync->pkt.type), sizeof(sync_packet_type), dest);
 }
 
 /*
@@ -350,7 +350,7 @@ void SendSyncPacket(synctype* sync, int dest)
 =============
 */
 
-boolean SlavePhaseHandler(synctype* sync)
+boolean SlavePhaseHandler(sync_type* sync)
 {
 	boolean done;
 
@@ -387,7 +387,7 @@ boolean SlavePhaseHandler(synctype* sync)
 =============
 */
 
-boolean MasterPhaseHandler(synctype* sync)
+boolean MasterPhaseHandler(sync_type* sync)
 {
 	boolean done;
 
@@ -430,10 +430,10 @@ boolean MasterPhaseHandler(synctype* sync)
 void ComSetTime(void)
 {
 	int i;
-	syncpackettype* syncpacket;
+	sync_packet_type* syncpacket;
 	boolean done = false;
 
-	syncpacket = (syncpackettype*)SafeMalloc(sizeof(syncpackettype));
+	syncpacket = (sync_packet_type*)SafeMalloc(sizeof(sync_packet_type));
 
 	// Sync clocks
 
@@ -484,7 +484,7 @@ void ComSetTime(void)
 
 		for (i = 0; i < nump; i++)
 		{
-			WritePacket(&(syncpacket->type), sizeof(syncpackettype), i);
+			WritePacket(&(syncpacket->type), sizeof(sync_packet_type), i);
 		}
 
 		while (GetTicCount() < time + (VBLCOUNTER / 4))
@@ -492,7 +492,7 @@ void ComSetTime(void)
 
 		for (i = 0; i < nump; i++)
 		{
-			WritePacket(&(syncpacket->type), sizeof(syncpackettype), i);
+			WritePacket(&(syncpacket->type), sizeof(sync_packet_type), i);
 		}
 
 		if (standalone == true)
@@ -506,7 +506,7 @@ void ComSetTime(void)
 
 			if (ReadPacket() && (badpacket == 0))
 			{
-				memcpy(syncpacket, &(ROTTpacket[0]), sizeof(syncpackettype));
+				memcpy(syncpacket, &(ROTTpacket[0]), sizeof(sync_packet_type));
 				if (syncpacket->type == COM_START)
 				{
 					controlsynctime = syncpacket->clocktime;
@@ -538,7 +538,7 @@ void ComSetTime(void)
 =
 =============
 */
-void InitialMasterSync(synctype* sync, int client)
+void InitialMasterSync(sync_type* sync, int client)
 {
 	boolean done = false;
 	int i;
@@ -594,7 +594,7 @@ void InitialMasterSync(synctype* sync, int client)
 =
 =============
 */
-void InitialSlaveSync(synctype* sync)
+void InitialSlaveSync(sync_type* sync)
 {
 	boolean done = false;
 
@@ -642,9 +642,9 @@ void SyncTime(int client)
 	int dtime[NUMSYNCPHASES];
 	boolean done;
 	int i;
-	synctype* sync;
+	sync_type* sync;
 
-	sync = (synctype*)SafeMalloc(sizeof(synctype));
+	sync = (sync_type*)SafeMalloc(sizeof(sync_type));
 
 	if (((networkgame == true) && (IsServer == true)) ||
 		((networkgame == false) && (consoleplayer == 0)))

--- a/src/rt_debug.c
+++ b/src/rt_debug.c
@@ -53,7 +53,7 @@ typedef struct
 {
 	char code[15];
 	byte length;
-} CodeStruct;
+} cheatcode_t;
 
 enum
 {
@@ -164,7 +164,7 @@ enum
 	MAXCODES
 };
 
-CodeStruct Codes[MAXCODES + 6] = {
+cheatcode_t Codes[MAXCODES + 6] = {
 	{"TIHSHO", 6},		  // richocheting rockets LT++
 	{"SIHTTNAWTNOD", 12}, // ricocheting rockets   LT++
 	{"KCITSPID", 8},	  // enable cheats

--- a/src/rt_door.h
+++ b/src/rt_door.h
@@ -45,7 +45,7 @@ typedef enum
 	ev_mtd, // moving to destination
 	// door at elevator location open
 	ev_doorclosing // door at elevator location closed
-} estate;
+} elevator_state;
 
 typedef enum
 {

--- a/src/rt_draw.c
+++ b/src/rt_draw.c
@@ -5238,14 +5238,14 @@ void DoInBetweenCinematic(int yoffset, int lump, int delay, char* string)
 #define NUMFIRSTCREDITMESSAGES	22
 #define NUMSECONDCREDITMESSAGES 28
 
-typedef struct CreditType
+typedef struct CreditText
 {
 	char text[80];
 	byte font;
 	byte endy;
-} CreditType;
+} CreditText;
 
-CreditType FirstCredits[NUMFIRSTCREDITMESSAGES] = {
+CreditText FirstCredits[NUMFIRSTCREDITMESSAGES] = {
 	{"Rise of the Triad Credits", 0, 0},
 	{"COPYRIGHT (c) 1995 Apogee Software Ltd.", 1, 10},
 	{"Apogee's Developers of Incredible Power", 1, 20},
@@ -5269,7 +5269,7 @@ CreditType FirstCredits[NUMFIRSTCREDITMESSAGES] = {
 	{"John Carmack  Ken Silverman  Gregor Punchatz", 1, 184},
 };
 
-CreditType SecondCredits[NUMSECONDCREDITMESSAGES] = {
+CreditText SecondCredits[NUMSECONDCREDITMESSAGES] = {
 	{"Rise of the Triad Credits", 0, 0},
 	{"COPYRIGHT (c) 1995 Apogee Software Ltd.", 1, 10},
 	{"Executive Producers", 0, 20},
@@ -5299,7 +5299,7 @@ CreditType SecondCredits[NUMSECONDCREDITMESSAGES] = {
 	{"Loyal, Ric, Teller, Amano", 1, 190},
 };
 
-void DrawPreviousCredits(int num, CreditType* Credits)
+void DrawPreviousCredits(int num, CreditText* Credits)
 {
 	int width;
 	int height;
@@ -5327,7 +5327,7 @@ void DrawPreviousCredits(int num, CreditType* Credits)
 //******************************************************************************
 
 extern boolean dopefish;
-void WarpCreditString(int time, byte* back, int num, CreditType* Credits)
+void WarpCreditString(int time, byte* back, int num, CreditText* Credits)
 {
 	int dy;
 	int cy;

--- a/src/rt_main.c
+++ b/src/rt_main.c
@@ -1697,7 +1697,7 @@ void UpdateGameObjects(void)
 	int j;
 	volatile int atime;
 	objtype *ob, *temp;
-	battle_status BattleStatus;
+	battle_state BattleStatus;
 
 	if (controlupdatestarted == 0)
 	{

--- a/src/rt_main.h
+++ b/src/rt_main.h
@@ -107,7 +107,7 @@ typedef struct
 	int autorun;
 
 	// Battle Options
-	battle_type BattleOptions;
+	battle_cfg_type BattleOptions;
 
 	boolean SpawnCollectItems;
 	boolean SpawnEluder;

--- a/src/rt_map.c
+++ b/src/rt_map.c
@@ -61,9 +61,9 @@ typedef struct PType
 {
 	int x;
 	int y;
-} Ptype;
+} point_type;
 
-static Ptype arrows[8][7] = {
+static point_type arrows[8][7] = {
 	{{4, 2}, {2, 4}, {2, 3}, {0, 3}, {0, 1}, {2, 1}, {2, 0}},
 	{{4, 0}, {4, 3}, {3, 2}, {1, 4}, {0, 3}, {2, 1}, {1, 0}},
 	{{2, 0}, {4, 2}, {3, 2}, {3, 4}, {1, 4}, {1, 2}, {0, 2}},

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -118,7 +118,7 @@ font_t* tinyfont;
 
 boolean loadedgame = false;
 
-battle_type BATTLE_Options[battle_NumBattleModes];
+battle_cfg_type BATTLE_Options[battle_NumBattleModes];
 
 int quicksaveslot = -1;
 
@@ -1445,7 +1445,7 @@ void ControlPanel(byte scancode)
 // CP_MainMenu
 //
 //******************************************************************************
-menuitems CP_MainMenu(void)
+menu_items CP_MainMenu(void)
 
 {
 	int which;
@@ -7838,8 +7838,8 @@ void ShowBattleOption(boolean inmenu, int PosX, int PosY, int column, int Line,
 void ShowBattleOptions(boolean inmenu, int PosX, int PosY)
 
 {
-	battle_type* options;
-	battle_type BatOps;
+	battle_cfg_type* options;
+	battle_cfg_type BatOps;
 	char* string;
 	char text[80];
 	int width;

--- a/src/rt_menu.h
+++ b/src/rt_menu.h
@@ -146,7 +146,7 @@ typedef enum
 	viewscores,
 	backtodemo,
 	quit
-} menuitems;
+} menu_items;
 
 //****************************************************************************
 //
@@ -166,7 +166,7 @@ void FreeSavedScreenPtr(void);
 void CleanUpControlPanel(void);
 void SetUpControlPanel(void);
 void ControlPanel(byte scancode);
-menuitems CP_MainMenu(void);
+menu_items CP_MainMenu(void);
 int getASCII(void);
 void DoMainMenu(void);
 boolean CP_CheckQuick(byte scancode);

--- a/src/rt_msg.c
+++ b/src/rt_msg.c
@@ -40,7 +40,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 =============================================================================
 */
-messagetype Messages[MAXMSGS];
+message_type Messages[MAXMSGS];
 
 /*
 =============================================================================
@@ -216,7 +216,7 @@ void DeleteMessage(int num)
 	}
 
 	SafeFree(Messages[num].text);
-	memset(&Messages[num], 0, sizeof(messagetype));
+	memset(&Messages[num], 0, sizeof(message_type));
 
 	GetMessageOrder();
 }

--- a/src/rt_msg.h
+++ b/src/rt_msg.h
@@ -47,9 +47,9 @@ typedef struct msgt
 	byte flags;
 	int tictime;
 	char* text;
-} messagetype;
+} message_type;
 
-extern messagetype Messages[MAXMSGS];
+extern message_type Messages[MAXMSGS];
 
 extern boolean MessagesEnabled;
 

--- a/src/rt_net.h
+++ b/src/rt_net.h
@@ -241,7 +241,7 @@ typedef struct
 	unsigned Version;
 	boolean teamplay;
 	specials SpecialsTimes;
-	battle_type options;
+	battle_cfg_type options;
 	char battlefilename[20];
 	int randomseed;
 	boolean ludicrousgibs;

--- a/src/rt_playr.c
+++ b/src/rt_playr.c
@@ -77,7 +77,7 @@ specials CurrentSpecialsTimes = {
 
 int GRAVITY = NORMAL_GRAVITY;
 
-ROTTCHARS characters[5] = {{0x2100, 0x4800, 100, 2, 25},  // Taradino Cassatt
+character_stat characters[5] = {{0x2100, 0x4800, 100, 2, 25},  // Taradino Cassatt
 						   {0x2200, 0x5200, 85, 3, 32},	  // Thi Barrett
 						   {0x1f00, 0x4000, 150, 3, 20},  // Doug Wendt
 						   {0x2300, 0x5500, 70, 2, 33},	  // Lorelei Ni

--- a/src/rt_playr.h
+++ b/src/rt_playr.h
@@ -144,7 +144,7 @@ typedef struct
 	int hitpoints;
 	int accuracy;
 	int height;
-} ROTTCHARS;
+} character_stat;
 
 #define M_LINKSTATE(x, y)                                                      \
 	{                                                                          \
@@ -161,7 +161,7 @@ extern objtype* PLAYER[MAXPLAYERS];
 extern objtype* player;
 extern playertype PLAYERSTATE[MAXPLAYERS], *locplayerstate;
 
-extern ROTTCHARS characters[5];
+extern character_stat characters[5];
 
 extern weaponinfo FREE;
 extern statetype s_player;

--- a/src/rt_sound.c
+++ b/src/rt_sound.c
@@ -62,7 +62,7 @@ int fxnums[11] = {-1, -1, -1, -1, -1, -1, SoundScape, -1, -1, -1, -1};
 
 int MUSIC_GetPosition(void)
 {
-	songposition pos;
+	songtic pos;
 
 	MUSIC_GetSongPosition(&pos);
 	return pos.milliseconds;

--- a/src/rt_stat.c
+++ b/src/rt_stat.c
@@ -235,7 +235,7 @@ Local Variables GLOBAL VARIABLES
 
 =============================================================================
 */
-static awallinfo_t animwallsinfo[MAXANIMWALLS] = {
+static animwallinfo_t animwallsinfo[MAXANIMWALLS] = {
 	{3, 4, "FPLACE1\0"},   // lava wall
 	{3, 6, "ANIMY1\0"},	   // anim red
 	{3, 6, "ANIMR1\0"},	   // anim yellow

--- a/src/rt_ted.c
+++ b/src/rt_ted.c
@@ -97,7 +97,7 @@ char LevelName[80];
 // LOCAL VARIABLES
 //========================================
 
-static cachetype* cachelist;
+static cache_type* cachelist;
 static word cacheindex;
 static boolean CachingStarted = false;
 static char* ROTTMAPS = STANDARDGAMELEVELS;
@@ -166,7 +166,7 @@ int GetLumpForTile(int tile);
 
 /*--------------------------------------------------------------------------*/
 int CompareTags(s1p, s2p)
-cachetype *s1p, *s2p;
+cache_type *s1p, *s2p;
 {
 	// Sort according to lump
 	if (DoPanicMapping() == true)
@@ -176,9 +176,9 @@ cachetype *s1p, *s2p;
 		return SGN(s1p->lump - s2p->lump);
 }
 
-void SwitchCacheEntries(s1p, s2p) cachetype *s1p, *s2p;
+void SwitchCacheEntries(s1p, s2p) cache_type *s1p, *s2p;
 {
-	cachetype temp;
+	cache_type temp;
 
 	temp = *s1p;
 	*s1p = *s2p;
@@ -187,7 +187,7 @@ void SwitchCacheEntries(s1p, s2p) cachetype *s1p, *s2p;
 
 void SortPreCache(void)
 {
-	hsort((char*)cachelist, cacheindex, sizeof(cachetype), &CompareTags,
+	hsort((char*)cachelist, cacheindex, sizeof(cache_type), &CompareTags,
 		  &SwitchCacheEntries);
 }
 
@@ -206,7 +206,7 @@ void SetupPreCache(void)
 
 	CachingStarted = true;
 	cacheindex = 0;
-	cachelist = (cachetype*)SafeMalloc(MAXPRECACHE * (sizeof(cachetype)));
+	cachelist = (cache_type*)SafeMalloc(MAXPRECACHE * (sizeof(cache_type)));
 	DrawPreCache();
 }
 
@@ -1669,9 +1669,9 @@ void LoadTedMap(const char* extension, int mapnum)
 	int i;
 	int maphandle;
 	byte* buffer;
-	maptype mapheader;
+	map_type mapheader;
 	char name[200];
-	mapfiletype* tinf;
+	map_file_type* tinf;
 
 	//
 	// load maphead.ext (offsets and tileinfo for map file)
@@ -1707,7 +1707,7 @@ void LoadTedMap(const char* extension, int mapnum)
 	}
 
 	lseek(maphandle, pos, SEEK_SET);
-	SafeRead(maphandle, &mapheader, sizeof(maptype));
+	SafeRead(maphandle, &mapheader, sizeof(map_type));
 
 	for (i = 0; i < 3; i++)
 	{


### PR DESCRIPTION
Some simple but helpful changes to various typedefs in the codebase. Naming convention has generally been preserved where possible, but just expanded and reworded for less clunkiness. There is no consistent format yet. A lot of typedefs use _type at the end, or enum_ at the start. Ideally, it should be `_t` and `en_` respectively. Should be easy to grep for though, and this is just a simple pass for immediate improvement without risking naming conflicts.