### PR TITLE
Revert naming pass on audiolib

### DIFF
--- a/src/audiolib/_multivc.h
+++ b/src/audiolib/_multivc.h
@@ -83,7 +83,7 @@ typedef enum
 {
 	NoMoreData,
 	KeepPlaying
-} snd_playstate;
+} playbackstatus;
 
 typedef struct VoiceNode
 {
@@ -93,7 +93,7 @@ typedef struct VoiceNode
 	wavedata wavetype;
 	char bits;
 
-	snd_playstate (*GetSound)(struct VoiceNode* voice);
+	playbackstatus (*GetSound)(struct VoiceNode* voice);
 
 	void (*mix)(unsigned long position, unsigned long rate, const char* start,
 				unsigned long length);
@@ -131,13 +131,13 @@ typedef struct
 {
 	VoiceNode* start;
 	VoiceNode* end;
-} VoiceList;
+} VList;
 
 typedef struct
 {
 	unsigned char left;
 	unsigned char right;
-} AudioPan;
+} Pan;
 
 typedef signed short MONO16;
 typedef signed char MONO8;
@@ -199,10 +199,10 @@ static void MV_PlayVoice(VoiceNode* voice);
 static void MV_StopVoice(VoiceNode* voice);
 static void MV_ServiceVoc(void);
 
-static snd_playstate MV_GetNextVOCBlock(VoiceNode* voice);
-static snd_playstate MV_GetNextDemandFeedBlock(VoiceNode* voice);
-static snd_playstate MV_GetNextRawBlock(VoiceNode* voice);
-static snd_playstate MV_GetNextWAVBlock(VoiceNode* voice);
+static playbackstatus MV_GetNextVOCBlock(VoiceNode* voice);
+static playbackstatus MV_GetNextDemandFeedBlock(VoiceNode* voice);
+static playbackstatus MV_GetNextRawBlock(VoiceNode* voice);
+static playbackstatus MV_GetNextWAVBlock(VoiceNode* voice);
 
 static void MV_ServiceRecord(void);
 static VoiceNode* MV_GetVoice(int handle);

--- a/src/audiolib/fx_man.h
+++ b/src/audiolib/fx_man.h
@@ -65,7 +65,7 @@ enum FX_ERRORS
 	FX_DPMI_Error
 };
 
-enum fx_BLASTER_ts
+enum fx_BLASTER_Types
 {
 	fx_SB = 1,
 	fx_SBPro = 2,

--- a/src/audiolib/multivoc.c
+++ b/src/audiolib/multivoc.c
@@ -59,8 +59,8 @@ static VOLUME16* MV_ReverbTable = NULL;
 // static signed short MV_VolumeTable[ MV_MaxVolume + 1 ][ 256 ];
 static signed short MV_VolumeTable[63 + 1][256];
 
-// static AudioPan MV_PanTable[ MV_NumPanPositions ][ MV_MaxVolume + 1 ];
-static AudioPan MV_PanTable[MV_NumPanPositions][63 + 1];
+// static Pan MV_PanTable[ MV_NumPanPositions ][ MV_MaxVolume + 1 ];
+static Pan MV_PanTable[MV_NumPanPositions][63 + 1];
 
 static int MV_Installed = FALSE;
 static int MV_SoundCard = SoundBlaster;
@@ -556,7 +556,7 @@ static __inline unsigned int get_le16(void* p0)
 	return ((unsigned int)(BUILDSWAP_INTEL16(val)));
 }
 
-snd_playstate MV_GetNextVOCBlock(VoiceNode* voice)
+playbackstatus MV_GetNextVOCBlock(VoiceNode* voice)
 
 {
 	unsigned char* ptr;
@@ -831,7 +831,7 @@ snd_playstate MV_GetNextVOCBlock(VoiceNode* voice)
    Controls playback of demand fed data.
 ---------------------------------------------------------------------*/
 
-snd_playstate MV_GetNextDemandFeedBlock(VoiceNode* voice)
+playbackstatus MV_GetNextDemandFeedBlock(VoiceNode* voice)
 
 {
 	if (voice->BlockLength > 0)
@@ -869,7 +869,7 @@ snd_playstate MV_GetNextDemandFeedBlock(VoiceNode* voice)
    Controls playback of demand fed data.
 ---------------------------------------------------------------------*/
 
-snd_playstate MV_GetNextRawBlock(VoiceNode* voice)
+playbackstatus MV_GetNextRawBlock(VoiceNode* voice)
 
 {
 	if (voice->BlockLength <= 0)
@@ -906,7 +906,7 @@ snd_playstate MV_GetNextRawBlock(VoiceNode* voice)
    Controls playback of demand fed data.
 ---------------------------------------------------------------------*/
 
-snd_playstate MV_GetNextWAVBlock(VoiceNode* voice)
+playbackstatus MV_GetNextWAVBlock(VoiceNode* voice)
 
 {
 	if (voice->BlockLength <= 0)


### PR DESCRIPTION
Naming pass on audiolib folder broke it, and it's such a small change in a section of code people dont touch often that it isn't worth it.