### PR TITLE
Add FOV slider

### DIFF
--- a/src/WinRott.h
+++ b/src/WinRott.h
@@ -20,16 +20,13 @@ extern int iGLOBAL_HEALTH_Y;
 extern int iGLOBAL_AMMO_X;
 extern int iGLOBAL_AMMO_Y;
 
-extern int iGLOBAL_FOCALWIDTH;
-extern float fGLOBAL_FPFOCALWIDTH;
+extern int iGLOBAL_FOCALLENGTH;
 
 void EnableScreenStretch(void);
 void DisableScreenStretch(void);
 void WriteNewResolution(void);
-void RecalculateFocalWidth(void);
+void RecalculateFocalLength(void);
 /*
-#define FOCALWIDTH 160//160
-#define FPFOCALWIDTH 160.0//160.0
 
 
 

--- a/src/WinRott.h
+++ b/src/WinRott.h
@@ -20,8 +20,6 @@ extern int iGLOBAL_HEALTH_Y;
 extern int iGLOBAL_AMMO_X;
 extern int iGLOBAL_AMMO_Y;
 
-extern int iGLOBAL_FOCALLENGTH;
-
 void EnableScreenStretch(void);
 void DisableScreenStretch(void);
 void WriteNewResolution(void);

--- a/src/rt_cfg.c
+++ b/src/rt_cfg.c
@@ -87,7 +87,6 @@ bool autoAimMissileWeps = 0;
 bool autoAim = 1;
 bool allowMovementWithMouseYAxis = 1;
 int vfov = 90;
-int FocalWidthOffset = 0;
 int ScreenHeightToWriteToCfg = 0;
 int HudScaleToWriteToCfg = 0;
 int ScreenWidthToWriteToCfg = 0;
@@ -426,9 +425,6 @@ bool ParseConfigFile(void)
 
 		// Read in AutoAimMissileWeps
 		ReadBool("AutoAimMissileWeps", &autoAimMissileWeps);
-
-		// Read in scaleOffset
-		ReadInt("FocalWidthOffset", &FocalWidthOffset);
 
 		// Read in MouseEnabled
 		ReadBool("MouseEnabled", &mouseenabled);
@@ -1637,11 +1633,6 @@ void WriteConfig(void)
 	SafeWriteString(file, "; 0 - Missile weapons are not automatically aimed "
 						  "at targets. (ROTT default)\n");
 	WriteParameter(file, "AutoAimMissileWeps    ", autoAimMissileWeps);
-
-	// Write out scaleOffset
-	SafeWriteString(file, "\n;\n");
-	SafeWriteString(file, "; Field Of View offset\n");
-	WriteParameter(file, "FocalWidthOffset     ", FocalWidthOffset);
 
 	// Write out MouseEnabled
 

--- a/src/rt_cfg.c
+++ b/src/rt_cfg.c
@@ -86,6 +86,7 @@ bool borderlessWindow = 0;
 bool autoAimMissileWeps = 0;
 bool autoAim = 1;
 bool allowMovementWithMouseYAxis = 1;
+int vfov = 90;
 int FocalWidthOffset = 0;
 int ScreenHeightToWriteToCfg = 0;
 int HudScaleToWriteToCfg = 0;
@@ -446,6 +447,8 @@ bool ParseConfigFile(void)
 		ReadBool("DoomBobbing", &doombobbing);
 
 		ReadBool("WeaponColor", &blackwpns);
+
+		ReadInt("VerticalFOV", &vfov);
 
 		ReadInt("InverseMouse", &inverse_mouse);
 
@@ -1682,6 +1685,11 @@ void WriteConfig(void)
 	SafeWriteString(file, "; 1 - WeaponColor Enabled\n");
 	SafeWriteString(file, "; 0 - WeaponColor Disabled\n");
 	WriteParameter(file, "WeaponColor      ", blackwpns);
+
+	// Write out VerticalFov
+	SafeWriteString(file, "\n;\n");
+	SafeWriteString(file, "; 60-150 VFOV \n");
+	WriteParameter(file, "VerticalFOV      ", vfov);
 
 	// Write out InverseMouse
 	SafeWriteString(file, "\n;\n");

--- a/src/rt_cfg.h
+++ b/src/rt_cfg.h
@@ -32,6 +32,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 //****************************************************************************
 
+#define MINFOV 60
+#define MAXFOV 150
+
 extern int FXMode;
 extern int MusicMode;
 extern int MUvolume;

--- a/src/rt_cfg.h
+++ b/src/rt_cfg.h
@@ -45,7 +45,7 @@ extern bool blackwpns;
 extern bool doombobbing;
 extern bool halfmonkhp;
 extern bool disablelowhpsnd;
-
+extern int vfov;
 extern int joystickport;
 extern int mouseadjustment;
 extern int threshold;

--- a/src/rt_cfg.h
+++ b/src/rt_cfg.h
@@ -32,8 +32,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 //****************************************************************************
 
-#define MINFOV 60
-#define MAXFOV 150
+#define MINFOV 40
+#define MAXFOV 120
 
 extern int FXMode;
 extern int MusicMode;

--- a/src/rt_draw.c
+++ b/src/rt_draw.c
@@ -2040,7 +2040,7 @@ void WallRefresh(void)
 							 sintable[(GetCachedTic() << 5) & (FINEANGLES - 1)],
 							 (16 + 4))) &
 						(FINEANGLES - 1);
-			ChangeFocalWidth(FixedMulShift(
+			ChangeFocalLength(FixedMulShift(
 				40, sintable[(GetCachedTic() << 5) & (FINEANGLES - 1)], 16));
 		}
 		else

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -4628,7 +4628,12 @@ extern int vfov;
 
 void DoAdjustFOV(void)
 {
-	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", " deg");
+	if(vfov < MINFOV)
+		vfov = MINFOV;
+	if(vfov > MAXFOV)
+		vfov = MAXFOV;
+	
+	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 5, "block2", NULL, "Set FOV", "FOV: ", " deg");
 	DrawVisualsMenu();
 }
 

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -4625,6 +4625,7 @@ void CP_CrosshairMenu(void)
 }
 
 extern int FocalWidthOffset;
+extern int vfov;
 
 void DoAdjustFocalWidth(void)
 {

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -4628,7 +4628,7 @@ extern int vfov;
 
 void DoAdjustFOV(void)
 {
-	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", "degrees");
+	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", " degrees");
 	DrawVisualsMenu();
 }
 

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -1355,7 +1355,7 @@ void CleanUpControlPanel(void)
 
 	// change the focal width if modified
 
-	RecalculateFocalWidth();
+	RecalculateFocalLength();
 
 	INL_GetJoyDelta(joystickport, &joyx, &joyy);
 
@@ -4624,12 +4624,11 @@ void CP_CrosshairMenu(void)
 	DrawVisualsMenu();
 }
 
-// extern int FocalWidthOffset;
 extern int vfov;
 
 void DoAdjustFOV(void)
 {
-	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", "degrees")
+	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", "degrees");
 	DrawVisualsMenu();
 }
 

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -546,7 +546,7 @@ CP_MenuNames ExtOptionsNames[] = {
 
 CP_MenuNames ExtGameOptionsNames[] = {"LOW MEMORY MODE", "WEAPON RECOLOURS", "DOOM BOBBING", "NO LOW HP SOUND", "HALF MONK HEALTH"}; // erysdren added
 
-CP_MenuNames VisualOptionsNames[] = {"SCREEN RESOLUTION", "ADJUST FOCAL WIDTH",
+CP_MenuNames VisualOptionsNames[] = {"SCREEN RESOLUTION", "FIELD-OF-VIEW",
 									 "HUD SCALING", "DISPLAY OPTIONS", "CROSSHAIR OPTIONS"};
 
 CP_MenuNames CrosshairOptionsNames[] = {"COLOUR", "PARAMETERS",
@@ -634,7 +634,7 @@ void CP_CrosshairParameters(void);
 void DrawCrosshairOptionsButtons(void);
 
 CP_itemtype VisualsOptionsMenu[] = {{1, "", 'S', (menuptr)CP_ScreenResolution},
-									{1, "", 'F', (menuptr)DoAdjustFocalWidth},
+									{1, "", 'F', (menuptr)DoAdjustFOV},
 									{1, "", 'H', (menuptr)DoAdjustHudScale},
 									{1, "", 'D', (menuptr)CP_DisplayOptions},
 									{1, "", 'C', (menuptr)CP_CrosshairMenu}};
@@ -4624,13 +4624,14 @@ void CP_CrosshairMenu(void)
 	DrawVisualsMenu();
 }
 
-extern int FocalWidthOffset;
+// extern int FocalWidthOffset;
 extern int vfov;
 
-void DoAdjustFocalWidth(void)
+void DoAdjustFOV(void)
 {
-	SliderMenu(&FocalWidthOffset, 96, 0, 44, 81, 194, 4, "block2", NULL,
-			   "Adjust Focal Width", "Default", "You Crazy");
+	// SliderMenu(&FocalWidthOffset, 96, 0, 44, 81, 194, 4, "block2", NULL,
+	// 		   "Adjust Focal Width", "Default", "You Crazy");
+	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", "degrees")
 	DrawVisualsMenu();
 }
 

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -4629,8 +4629,6 @@ extern int vfov;
 
 void DoAdjustFOV(void)
 {
-	// SliderMenu(&FocalWidthOffset, 96, 0, 44, 81, 194, 4, "block2", NULL,
-	// 		   "Adjust Focal Width", "Default", "You Crazy");
 	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", "degrees")
 	DrawVisualsMenu();
 }

--- a/src/rt_menu.c
+++ b/src/rt_menu.c
@@ -4628,7 +4628,7 @@ extern int vfov;
 
 void DoAdjustFOV(void)
 {
-	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", " degrees");
+	BoundSliderMenu(&vfov, MAXFOV, MINFOV, 44, 81, 194, 2, "block2", NULL, "Set FOV", "FOV: ", " deg");
 	DrawVisualsMenu();
 }
 

--- a/src/rt_menu.h
+++ b/src/rt_menu.h
@@ -208,6 +208,6 @@ void UndoQuickSaveGame(void);
 void CP_CaptureTheTriadError(void);
 void CP_TeamPlayErrorMessage(void);
 void CP_ExtGameOptionsMenu(void);
-void DoAdjustFocalWidth(void);
+void DoAdjustFOV(void);
 
 #endif

--- a/src/rt_playr.c
+++ b/src/rt_playr.c
@@ -4914,7 +4914,7 @@ void CheckProtectionsAndPowerups(objtype* ob, playertype* pstate)
 		}
 		else if (ob->flags & FL_SHROOMS)
 		{
-			ResetFocalWidth();
+			ResetFocalLength();
 			SD_PlaySoundRTP(SD_LOSEMODESND, ob->x, ob->y);
 		}
 		else if (ob->flags & FL_FLEET)

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -84,7 +84,7 @@ byte* playermaps[MAXPLAYERCOLORS];
 short pixelangle[MAXSCREENWIDTH];
 byte gammatable[GAMMAENTRIES];
 int gammaindex;
-int focalwidth = 160;
+int focallength = 160;
 int yzangleconverter;
 byte uniformcolors[MAXPLAYERCOLORS] = {25,	222, 29, 206, 52, 6,
 									   155, 16,	 90, 129, 109};
@@ -118,26 +118,26 @@ void UpdatePeriodicLighting(void);
 /*
 ====================
 =
-= ResetFocalWidth
+= ResetFocalLength
 =
 ====================
 */
-void ResetFocalWidth(void)
+void ResetFocalLength(void)
 {
-	focalwidth = iGLOBAL_FOCALWIDTH; // FOCALWIDTH;
+	focallength = iGLOBAL_FOCALLENGTH;
 	SetViewDelta();
 }
 
 /*
 ====================
 =
-= ChangeFocalWidth
+= ChangeFocalLength
 =
 ====================
 */
-void ChangeFocalWidth(int amount)
+void ChangeFocalLength(int amount)
 {
-	focalwidth = iGLOBAL_FOCALWIDTH + amount; // FOCALWIDTH+amount;
+	focallength = iGLOBAL_FOCALLENGTH + amount;
 	SetViewDelta();
 }
 
@@ -158,12 +158,12 @@ void SetViewDelta(void)
 	//  and sprite x calculations
 	//
 
-	scale = (centerx * focalwidth) / (160);
+	scale = (centerx * focallength) / (160);
 	//
 	// divide heightnumerator by a posts distance to get the posts height for
 	// the heightbuffer.  The pixel height is height>>HEIGHTFRACTION
 	//
-	heightnumerator = ((int)(((float)focalwidth / 10) * centerx * 4096) * 64);
+	heightnumerator = ((int)(((float)focallength / 10) * centerx * 4096) * 64);
 }
 
 /*
@@ -183,9 +183,6 @@ void CalcProjection(void)
 	byte* ptr;
 	int length;
 	int* pangle;
-
-	// Already being called in ResetFocalWidth
-	//    SetViewDelta();
 
 	//
 	// load in tables file
@@ -333,7 +330,7 @@ void SetViewSize(int size)
 	// This now very accurately, truly converts player angles to screen angles.
 	int anglescale = (int)(16384 * ((float)sW / sH) + 8192);
 
-	yzangleconverter = (int)((anglescale * ((float)focalwidth / 160)) * ((float)viewheight / 200));
+	yzangleconverter = (int)((anglescale * ((float)focallength / 160)) * ((float)viewheight / 200));
 
 	// Center the view horizontally
 	screenx = (sW - viewwidth) >> 1;
@@ -356,10 +353,7 @@ void SetViewSize(int size)
 	// calculate trace angles and projection constants
 	//
 
-	ResetFocalWidth();
-
-	// Already being called in ResetFocalWidth
-	//   SetViewDelta();
+	ResetFocalLength();
 
 	CalcProjection();
 }

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -118,6 +118,35 @@ void UpdatePeriodicLighting(void);
 /*
 ====================
 =
+= FOVToFocalLength
+=
+====================
+*/
+
+extern int vfov;
+
+// https://wojtsterna.com/2024/01/09/field-of-view-horizontal-and-vertical-conversion/
+// https://stackoverflow.com/questions/18176215/how-to-select-focal-lengh-in-ray-tracing
+// this is the distance to the projection plane
+int FOVToFocalLength(void)
+{
+	// calculate horizontal fov from vertical fov
+	float hfov;
+	float f;
+	float aspectRatio = ((float)iGLOBAL_SCREENWIDTH / iGLOBAL_SCREENHEIGHT);
+
+	hfov = 2 * atan(aspectRatio * tan((float)vfov / 2));
+
+	// GooberMan mentioned in LE discord to multiply by 1.1 to get true FOV
+	// because ROTT is strange
+	f = (((float)iGLOBAL_SCREENWIDTH / 2) / tan(hfov / 2)) * 1.1;
+
+	return (int)round(f);
+}
+
+/*
+====================
+=
 = ResetFocalLength
 =
 ====================

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -209,7 +209,6 @@ void SetViewDelta(void)
 	// the heightbuffer.  The pixel height is height>>HEIGHTFRACTION
 	//
 	heightnumerator = ((uint64_t)(((float)focallength / 10) * centerx * 4096) * 64);
-	printf("%u\n", heightnumerator);
 }
 
 /*

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -135,7 +135,7 @@ int FOVToFocalLength(int fov)
 	// calculate horizontal fov from vertical fov
 	float hfov;
 	float f;
-	float aspectRatio = ((double)iGLOBAL_SCREENWIDTH / iGLOBAL_SCREENHEIGHT);
+	float aspectRatio = ((double)320 / 200);
 	float degToRad = M_PI / 180;
 
 	hfov = 2 * (atan((tan((double)(fov * degToRad) / 2)) * aspectRatio));
@@ -144,7 +144,7 @@ int FOVToFocalLength(int fov)
 
 	// GooberMan mentioned in LE discord to divide by 1.1 to get true FOV
 	// because ROTT is strange
-	f = (((double)200 / 2) / (tan((double)hfov / 2))) / 1.1;
+	f = (((double)200 / 2) / (tan((double)hfov / 2))) * 1.1;
 
 	// printf("len: %f\n", f);
 

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 #include "rt_def.h"
+#include "rt_cfg.h"
 #include "rt_view.h"
 #include "z_zone.h"
 #include "w_wad.h"
@@ -128,14 +129,14 @@ extern int vfov;
 // https://wojtsterna.com/2024/01/09/field-of-view-horizontal-and-vertical-conversion/
 // https://stackoverflow.com/questions/18176215/how-to-select-focal-lengh-in-ray-tracing
 // this is the distance to the projection plane
-int FOVToFocalLength(void)
+int FOVToFocalLength(int fov)
 {
 	// calculate horizontal fov from vertical fov
 	float hfov;
 	float f;
 	float aspectRatio = ((float)iGLOBAL_SCREENWIDTH / iGLOBAL_SCREENHEIGHT);
 
-	hfov = 2 * atan(aspectRatio * tan((float)vfov / 2));
+	hfov = 2 * atan(aspectRatio * tan((float)fov / 2));
 
 	// GooberMan mentioned in LE discord to multiply by 1.1 to get true FOV
 	// because ROTT is strange
@@ -153,7 +154,7 @@ int FOVToFocalLength(void)
 */
 void ResetFocalLength(void)
 {
-	focallength = iGLOBAL_FOCALLENGTH;
+	focallength = FOVToFocalLength(vfov);
 	SetViewDelta();
 }
 
@@ -166,7 +167,17 @@ void ResetFocalLength(void)
 */
 void ChangeFocalLength(int amount)
 {
-	focallength = iGLOBAL_FOCALLENGTH + amount;
+	int min = FOVToFocalLength(MAXFOV);
+	int max = FOVToFocalLength(MAXFOV);
+
+	focallength = FOVToFocalLength(vfov) - amount;
+
+	// clamp fov for shroom mode etc
+	if(focallength < min)
+		focallength = min;
+	if(focallength < max)
+		focallength = max;
+
 	SetViewDelta();
 }
 

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -67,7 +67,7 @@ int baseminshade;
 int basemaxshade;
 int viewheight;
 int viewwidth;
-longword heightnumerator;
+uint64_t heightnumerator;
 fixed scale;
 int screenofs;
 int centerx;
@@ -113,7 +113,6 @@ static int lightningsoundtime = 0;
 static bool periodic = false;
 static int periodictime = 0;
 
-void SetViewDelta(void);
 void UpdatePeriodicLighting(void);
 
 /*
@@ -144,7 +143,7 @@ int FOVToFocalLength(int fov)
 
 	// GooberMan mentioned in LE discord to divide by 1.1 to get true FOV
 	// because ROTT is strange
-	f = (((double)200 / 2) / (tan((double)hfov / 2))) * 1.1;
+	f = (((double)200 / 2) / (tan((double)hfov / 2))) / 1.1;
 
 	// printf("len: %f\n", f);
 
@@ -204,12 +203,13 @@ void SetViewDelta(void)
 	//  and sprite x calculations
 	//
 
-	scale = (centerx * focallength) / (160);
+	scale = (fixed)((centerx / (float)160) * focallength);
 	//
 	// divide heightnumerator by a posts distance to get the posts height for
 	// the heightbuffer.  The pixel height is height>>HEIGHTFRACTION
 	//
-	heightnumerator = ((int)(((float)focallength / 10) * centerx * 4096) * 64);
+	heightnumerator = ((uint64_t)(((float)focallength / 10) * centerx * 4096) * 64);
+	printf("%u\n", heightnumerator);
 }
 
 /*

--- a/src/rt_view.c
+++ b/src/rt_view.c
@@ -129,18 +129,24 @@ extern int vfov;
 // https://wojtsterna.com/2024/01/09/field-of-view-horizontal-and-vertical-conversion/
 // https://stackoverflow.com/questions/18176215/how-to-select-focal-lengh-in-ray-tracing
 // this is the distance to the projection plane
+// we need to do our math in the original 320x200 viewport
 int FOVToFocalLength(int fov)
 {
 	// calculate horizontal fov from vertical fov
 	float hfov;
 	float f;
-	float aspectRatio = ((float)iGLOBAL_SCREENWIDTH / iGLOBAL_SCREENHEIGHT);
+	float aspectRatio = ((double)iGLOBAL_SCREENWIDTH / iGLOBAL_SCREENHEIGHT);
+	float degToRad = M_PI / 180;
 
-	hfov = 2 * atan(aspectRatio * tan((float)fov / 2));
+	hfov = 2 * (atan((tan((double)(fov * degToRad) / 2)) * aspectRatio));
 
-	// GooberMan mentioned in LE discord to multiply by 1.1 to get true FOV
+	// printf("fov: %d, hfov: %f\n", fov, (hfov * 180 / M_PI));
+
+	// GooberMan mentioned in LE discord to divide by 1.1 to get true FOV
 	// because ROTT is strange
-	f = (((float)iGLOBAL_SCREENWIDTH / 2) / tan(hfov / 2)) * 1.1;
+	f = (((double)200 / 2) / (tan((double)hfov / 2))) / 1.1;
+
+	// printf("len: %f\n", f);
 
 	return (int)round(f);
 }

--- a/src/rt_view.h
+++ b/src/rt_view.h
@@ -89,7 +89,7 @@ extern int baseminshade;
 extern int basemaxshade;
 extern int viewheight;
 extern int viewwidth;
-extern longword heightnumerator;
+extern uint64_t heightnumerator;
 extern fixed scale;
 extern int screenofs;
 extern int centerx;
@@ -108,6 +108,7 @@ extern int lightninglevel;
 extern bool lightning;
 extern int darknesslevel;
 
+void SetViewDelta(void);
 int FOVToFocalLength(int fov);
 void DrawCPUJape(void);
 void SetupScreen(bool flip);

--- a/src/rt_view.h
+++ b/src/rt_view.h
@@ -31,9 +31,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define HEIGHTFRACTION 6
 #define MAXVIEWSIZES   11
 
-// #define FOCALWIDTH 160//160
-// #define FPFOCALWIDTH 160.0//160.0
-
 #define NUMGAMMALEVELS 8
 #define GAMMAENTRIES   (64 * 8)
 
@@ -105,7 +102,7 @@ extern byte* redmap;
 extern byte* blckmap;
 extern int weaponscale;
 extern int viewsize;
-extern int focalwidth;
+extern int focallength;
 extern int yzangleconverter;
 extern int lightninglevel;
 extern bool lightning;
@@ -113,8 +110,8 @@ extern int darknesslevel;
 
 void DrawCPUJape(void);
 void SetupScreen(bool flip);
-void ResetFocalWidth(void);
-void ChangeFocalWidth(int amount);
+void ResetFocalLength(void);
+void ChangeFocalLength(int amount);
 void SetViewSize(int size);
 void LoadColorMap(void);
 void UpdateLightLevel(int area);

--- a/src/rt_view.h
+++ b/src/rt_view.h
@@ -108,7 +108,7 @@ extern int lightninglevel;
 extern bool lightning;
 extern int darknesslevel;
 
-int FOVToFocalLength(void);
+int FOVToFocalLength(int fov);
 void DrawCPUJape(void);
 void SetupScreen(bool flip);
 void ResetFocalLength(void);

--- a/src/rt_view.h
+++ b/src/rt_view.h
@@ -108,6 +108,7 @@ extern int lightninglevel;
 extern bool lightning;
 extern int darknesslevel;
 
+int FOVToFocalLength(void);
 void DrawCPUJape(void);
 void SetupScreen(bool flip);
 void ResetFocalLength(void);

--- a/src/winrott.c
+++ b/src/winrott.c
@@ -16,8 +16,7 @@ int iGLOBAL_HEALTH_Y;
 int iGLOBAL_AMMO_X;
 int iGLOBAL_AMMO_Y;
 
-int iGLOBAL_FOCALWIDTH;
-float fGLOBAL_FPFOCALWIDTH;
+int iGLOBAL_FOCALLENGTH;
 
 int iG_X_center;
 int iG_Y_center;
@@ -32,10 +31,9 @@ extern int viewwidth;
 //----------------------------------------------------------------------
 #define FINEANGLES 2048
 
-void RecalculateFocalWidth(void)
+void RecalculateFocalLength(void)
 {
-	iGLOBAL_FOCALWIDTH = 160 - FocalWidthOffset;
-	fGLOBAL_FPFOCALWIDTH = (float)FocalWidthOffset;
+	iGLOBAL_FOCALLENGTH = 160;
 }
 
 void SetRottScreenRes(int Width, int Height)
@@ -44,8 +42,7 @@ void SetRottScreenRes(int Width, int Height)
 	iGLOBAL_SCREENWIDTH = Width;
 	iGLOBAL_SCREENHEIGHT = Height;
 
-	iGLOBAL_FOCALWIDTH = 160 - FocalWidthOffset;
-	fGLOBAL_FPFOCALWIDTH = (float)iGLOBAL_FOCALWIDTH;
+	iGLOBAL_FOCALLENGTH = 160;
 
 	int middleWidth = Width / 2;
 

--- a/src/winrott.c
+++ b/src/winrott.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include "WinRott.h"
 #include "modexlib.h"
+#include "rt_def.h"
+#include "rt_view.h"
 
 // typedef unsigned char byte;
 
@@ -16,8 +18,6 @@ int iGLOBAL_HEALTH_Y;
 int iGLOBAL_AMMO_X;
 int iGLOBAL_AMMO_Y;
 
-int iGLOBAL_FOCALLENGTH;
-
 int iG_X_center;
 int iG_Y_center;
 
@@ -27,13 +27,14 @@ bool iG_aimCross = 0;
 
 extern int viewheight;
 extern int viewwidth;
+extern int vfov;
 
 //----------------------------------------------------------------------
 #define FINEANGLES 2048
 
 void RecalculateFocalLength(void)
 {
-	iGLOBAL_FOCALLENGTH = 160;
+	focallength = FOVToFocalLength(vfov);
 }
 
 void SetRottScreenRes(int Width, int Height)
@@ -42,7 +43,7 @@ void SetRottScreenRes(int Width, int Height)
 	iGLOBAL_SCREENWIDTH = Width;
 	iGLOBAL_SCREENHEIGHT = Height;
 
-	iGLOBAL_FOCALLENGTH = 160;
+	focallength = FOVToFocalLength(vfov);
 
 	int middleWidth = Width / 2;
 

--- a/src/winrott.c
+++ b/src/winrott.c
@@ -28,7 +28,7 @@ bool iG_aimCross = 0;
 
 extern int viewheight;
 extern int viewwidth;
-extern int FocalWidthOffset;
+
 //----------------------------------------------------------------------
 #define FINEANGLES 2048
 

--- a/src/winrott.c
+++ b/src/winrott.c
@@ -35,6 +35,7 @@ extern int vfov;
 void RecalculateFocalLength(void)
 {
 	focallength = FOVToFocalLength(vfov);
+	SetViewDelta();
 }
 
 void SetRottScreenRes(int Width, int Height)
@@ -44,6 +45,7 @@ void SetRottScreenRes(int Width, int Height)
 	iGLOBAL_SCREENHEIGHT = Height;
 
 	focallength = FOVToFocalLength(vfov);
+	SetViewDelta();
 
 	int middleWidth = Width / 2;
 


### PR DESCRIPTION
In creating my own raycaster, I was experimenting with planeY, the distance to the projection plane, and found it had the same effect as focal width in ROTT. I only ever see focal length mentioned wrt raycasting engines, so I believe focal width is a misnomer and actually represents focal length. I found some good resources on VFOV, HFOV, and focal length calculation, so implementing this was somewhat trivial. I also took some advice from GooberMan. Refactored a bit and cleared out all the leftover winrott crap.